### PR TITLE
Adds GetBagName function

### DIFF
--- a/Function/Bag.d.lua
+++ b/Function/Bag.d.lua
@@ -1,8 +1,10 @@
 ---@meta
 
--- TODO
 --- Get the name of one of the player's bags.
--- function GetBagName(bagID) end
+---@param bagID BagId number of the bag the item is in, 0 is your backpack, 1-4 are the four additional bags, numbered right to left. When bank is opened, more numbers can be used for bank bags.
+---@return string? bagName the name of the specified bag if the number is valid; nil otherwise
+--- [Open Documentation](https://wowpedia.fandom.com/wiki/API_GetBagName?oldid=102096)
+function GetBagName(bagID) end
 
 ---@param bagId BagId
 ---@param slot integer


### PR DESCRIPTION
I have found the API behaves differently than what wiki says. The [wiki](https://wowpedia.fandom.com/wiki/API_GetBagName?oldid=102096) says if bank is open, we can get bank bags starting from number 6, but from my testing, on a cmangos local server, I get bank bags from number 5. So I just left out bank bag numbers in the comments.