### PR TITLE
fix(api): update UnitDebuff return signature

### DIFF
--- a/Client/Enums.d.lua
+++ b/Client/Enums.d.lua
@@ -577,3 +577,9 @@ Note: The fourth number does not always stand for who made an item; it usually a
 --- | "contested"
 --- | "hostile" Zone controlled by opposing faction.
 --- | "sanctuary" (TBC onward?) Zone does not allow pvp combat.
+
+---@alias DebuffDispelType
+--- | "Magic"
+--- | "Curse"
+--- | "Poison"
+--- | "Disease"

--- a/Client/Enums.d.lua
+++ b/Client/Enums.d.lua
@@ -564,6 +564,7 @@ Note: The fourth number does not always stand for who made an item; it usually a
 --- | "raidpet39"
 --- | "raidpet40"
 --- | "target" The currently targeted unit. Not clear from wiki if macros can change this value.
+--- | "targettarget" The target of the currently targeted unit.
 
 ---@alias VerticalJustify
 --- | "TOP"

--- a/Client/Function/Aura.d.lua
+++ b/Client/Function/Aura.d.lua
@@ -50,7 +50,7 @@ function GetPlayerBuffTimeLeft(buffIndex) end
 ---@param buffIndex integer Index of the buff to retrieve, starting at 1. Max is 32 for party/pet; target's cap is unconfirmed (observed around 8).
 ---@param showCastable? nil|1 If present and 1, only buffs castable by the player are returned.
 ---@return nil|string buffTexture The icon texture path of the indicated buff, or nil if no buff.
----@return nil|number buffApplications The number of times the buff has been applied to the target. Returns 0 for any buff which doesn't stack.
+---@return nil|number buffApplications The number of times the buff has been applied to the target. Returns 1 for any buff which doesn't stack.
 ---@return nil|number buffID The unique identifier for the buff. (if supported by core).
 ---@nodiscard
 function UnitBuff(unit, buffIndex, showCastable) end
@@ -61,7 +61,7 @@ function UnitBuff(unit, buffIndex, showCastable) end
 ---@param debuffIndex integer The index of the debuff to retrieve info for. Starts at 1. The maximum index is 16 for party/pet/target debuffs.
 ---@param showDispellable? nil|1 Can be 0, 1, or nil. If present and 1, then only debuffs will be returned which are dispellable by the player. Index is still starting with 1 and counting up.
 ---@return nil|string debuffTexture The icon texture path of the indicated debuff, or nil if no debuff.
----@return nil|number  debuffApplications The number of times the debuff has been applied to the target. Returns 0 for any debuff which doesn't stack.
+---@return nil|number debuffApplications The number of times the debuff has been applied to the target. Returns 1 for any debuff which doesn't stack.
 ---@return nil|DebuffDispelType debuffDispelType The debuff dispel type. Can be "Magic", "Curse", "Poison", "Disease" or nil if not dispellable.
 ---@return nil|number debuffID The unique identifier for the debuff. (if supported by core).
 ---@nodiscard

--- a/Client/Function/Aura.d.lua
+++ b/Client/Function/Aura.d.lua
@@ -57,7 +57,6 @@ function UnitBuff(unit, buffIndex, showCastable) end
 
 --- Retrieves info about a debuff of a certain unit.
 --- As IDs are unique, they are more reliable than texture matching.
----@alias DebuffDispelType "Magic"|"Curse"|"Poison"|"Disease"
 ---@param unitID UnitId The unit ID you want debuff information for - "player", "target", "pet" etc
 ---@param debuffIndex integer The index of the debuff to retrieve info for. Starts at 1. The maximum index is 16 for party/pet/target debuffs.
 ---@param showDispellable? nil|1 Can be 0, 1, or nil. If present and 1, then only debuffs will be returned which are dispellable by the player. Index is still starting with 1 and counting up.

--- a/Client/Function/Aura.d.lua
+++ b/Client/Function/Aura.d.lua
@@ -45,29 +45,25 @@ function GetPlayerBuffTexture(buffIndex) end
 function GetPlayerBuffTimeLeft(buffIndex) end
 
 --- Retrieves info about a buff of a certain unit.
---- - TODO return values taken from 2008 wiki. Might be inaccurate.
----@param unit UnitId
----@param index integer The index of the debuff to retrieve info for. Starts at 1, maximum 40.
----@param showCastable? nil|1
----@return string name The name of the spell or effect of the debuff. This is the name shown in yellow when you mouse over the icon.
----@return string rank The rank of the spell or effect that caused the debuff. Returns "" if there is no rank.
----@return string icon Probably a texture path??
----@return integer count The number of times the debuff has been applied to the target. Returns 0 for any debuff which doesn't stack.
----@return nil|string debuffType The type of the debuff: Magic, Disease, Poison, Curse, or nothing for those with out a type.
----@return nil|number duration The full duration of the debuff in seconds; nil if the debuff was not cast by the player.
+--- As IDs are unique, they are more reliable than texture matching.
+---@param unitID UnitId The unit ID you want buff information for - "player", "target", "pet" etc
+---@param buffIndex integer Index of the buff to retrieve, starting at 1. Max is 32 for party/pet; target's cap is unconfirmed (observed around 8).
+---@param showCastable? nil|1 If present and 1, only buffs castable by the player are returned.
+---@return nil|string buffTexture The icon texture path of the indicated buff, or nil if no buff.
+---@return nil|number buffApplications The number of times the buff has been applied to the target. Returns 0 for any buff which doesn't stack.
+---@return nil|number buffID The unique identifier for the buff. (if supported by core).
 ---@nodiscard
-function UnitBuff(unit, index, showCastable) end
+function UnitBuff(unit, buffIndex, showCastable) end
 
 --- Retrieves info about a debuff of a certain unit.
---- - TODO return values taken from 2008 wiki. Might be inaccurate.
----@param unit UnitId
----@param index integer The index of the debuff to retrieve info for. Starts at 1, maximum 40.
----@param showDispellable? nil|1
----@return string name The name of the spell or effect of the debuff. This is the name shown in yellow when you mouse over the icon.
----@return string rank The rank of the spell or effect that caused the debuff. Returns "" if there is no rank.
----@return string icon Probably a texture path??
----@return integer count The number of times the debuff has been applied to the target. Returns 0 for any debuff which doesn't stack.
----@return nil|string debuffType The type of the debuff: Magic, Disease, Poison, Curse, or nothing for those with out a type.
----@return nil|number duration The full duration of the debuff in seconds; nil if the debuff was not cast by the player.
+--- As IDs are unique, they are more reliable than texture matching.
+---@alias DebuffDispelType "Magic"|"Curse"|"Poison"|"Disease"
+---@param unitID UnitId The unit ID you want debuff information for - "player", "target", "pet" etc
+---@param debuffIndex integer The index of the debuff to retrieve info for. Starts at 1. The maximum index is 16 for party/pet/target debuffs.
+---@param showDispellable? nil|1 Can be 0, 1, or nil. If present and 1, then only debuffs will be returned which are dispellable by the player. Index is still starting with 1 and counting up.
+---@return nil|string debuffTexture The icon texture path of the indicated debuff, or nil if no debuff.
+---@return nil|number  debuffApplications The number of times the debuff has been applied to the target. Returns 0 for any debuff which doesn't stack.
+---@return nil|DebuffDispelType debuffDispelType The debuff dispel type. Can be "Magic", "Curse", "Poison", "Disease" or nil if not dispellable.
+---@return nil|number debuffID The unique identifier for the debuff. (if supported by core).
 ---@nodiscard
-function UnitDebuff(unit, index, showDispellable) end
+function UnitDebuff(unit, debuffIndex, showDispellable) end

--- a/Client/Function/Aura.d.lua
+++ b/Client/Function/Aura.d.lua
@@ -51,7 +51,6 @@ function GetPlayerBuffTimeLeft(buffIndex) end
 ---@param showCastable? nil|1 If present and 1, only buffs castable by the player are returned.
 ---@return nil|string buffTexture The icon texture path of the indicated buff, or nil if no buff.
 ---@return nil|number buffApplications The number of times the buff has been applied to the target. Returns 1 for any buff which doesn't stack.
----@return nil|number buffID The unique identifier for the buff. (if supported by core).
 ---@nodiscard
 function UnitBuff(unit, buffIndex, showCastable) end
 
@@ -63,6 +62,5 @@ function UnitBuff(unit, buffIndex, showCastable) end
 ---@return nil|string debuffTexture The icon texture path of the indicated debuff, or nil if no debuff.
 ---@return nil|number debuffApplications The number of times the debuff has been applied to the target. Returns 1 for any debuff which doesn't stack.
 ---@return nil|DebuffDispelType debuffDispelType The debuff dispel type. Can be "Magic", "Curse", "Poison", "Disease" or nil if not dispellable.
----@return nil|number debuffID The unique identifier for the debuff. (if supported by core).
 ---@nodiscard
 function UnitDebuff(unit, debuffIndex, showDispellable) end


### PR DESCRIPTION
Hi @SabineWren, thank you for maintaining this project. I hope I've done everything correctly here. But let me know.

I am currently using these definitions to help convert (my personal Multiboxing scripts for 1.12.1) a large codebase (30k+ lines of Lua) and noticed that UnitDebuff and UnitBuff do not accurately reflect the 1.12.1 WoW implementation. The existing types seem to be derived from later versions of WoW, which causes type mismatches during development.

As seen in implementations by developers like @Shagu, the return values for UnitDebuff & UnitBuff in Vanilla are structured differently than the 2008-era wiki suggests. My personal testing confirms a return order of `texture`, `applications`, `dispelType`, `id` (UnitDebuff) & `texture`, `applications`, `id` (UnitBuff).

Example convert function from a Vanilla/TBC addon: 
```
function UnitDebuff(unitstr, i)
  -- fake return values to be vanilla alike
  local name, rank, texture, stacks, dtype, duration, timeLeft = _G.UnitDebuff(unitstr, i)
  return texture, stacks, dtype
end
```

I have updated the return types and parameters for both functions to match the actual core implementation. I have also added a `DebuffDispelType `alias to improve type safety and provide better IDE autocompletion. Because they should be immune to localization.

Included are some examples of how these functions are being used in practice, which this PR now supports correctly."
```
function DebuffScorchAmount()
    for debuffIndex = 1, 16 do
        local debuffTexture, debuffApplications, debuffDispelType = UnitDebuff("target", debuffIndex)
        if debuffTexture == "Interface\\Icons\\Spell_Fire_SoulBurn" and debuffDispelType == "Magic" then
            return debuffApplications or 0
        end
    end
    return 0
end
```
```
function AmountOfBuffs()
    local buffCount = 0

    for i = 1, 32 do
        local texture, applications = UnitBuff("player", i)

        if texture then
            if applications > 1 then
                buffCount = buffCount * applications
            else
                buffCount = buffCount + 1
            end
        end
    end

    return buffCount
end
```

I will most likely encounter more issues later down the line. So I'll try and keep track of this PR