### PR TITLE
Improved CastSpellByName

### DIFF
--- a/Client/Function/Spell.d.lua
+++ b/Client/Function/Spell.d.lua
@@ -15,8 +15,9 @@ function CastSpell(spellIndex, bookType) end
 --- - ex. CastSpellByName("Flash Heal(Rank 2)") Casts on target at rank 2
 --- - ex. CastSpellByName("Flash Heal") Casts on target
 --- - ex. CastSpellByName("Flash Heal", 1) Casts on self
+--- - ex. CastSpellByName("Flash Heal", true) Casts on self
 ---@param name string
----@param isSelf? nil|1
+---@param isSelf? nil|boolean|1
 ---@return nil
 function CastSpellByName(name, isSelf) end
 


### PR DESCRIPTION
Improved type documentation for CastSpellByName.
It is able to accept true & 1 for self casting. 
And any unknown value to make sure it does not self cast. But keep it simple and allow false to make it visually clear that this spell wont cast on self. Only somebody that's crazy would use a string or something else there

https://github.com/user-attachments/assets/fad266b0-d21d-4f1e-bfaa-f634c200c23a

Scuffed video but wasn't going to type the scripts lol