### PR TITLE
Added 0 | None to SetRaidTarget

### DIFF
--- a/Client/Enums.d.lua
+++ b/Client/Enums.d.lua
@@ -428,6 +428,7 @@ Note: The fourth number does not always stand for who made an item; it usually a
 ---@alias RaidIndex 1|2|3|4|5|6|7|8|9|10|11|12|13|14|15|16|17|18|19|20|21|22|23|24|25|26|27|28|29|30|31|32|33|34|35|36|37|38|39|40
 
 ---@alias RaidMark
+--- | 0 None
 --- | 1 Star
 --- | 2 Circle
 --- | 3 Diamond


### PR DESCRIPTION
Added support for `0 | None` because running `/run SetRaidTarget("target", 0)` would unmark the current target.

@SabineWren Any reason it wasn't there before?

https://github.com/user-attachments/assets/e90fe489-d1b2-45bb-87ce-77c3b1f6ec26

