### PR TITLE
SendChatMessage added "RAID_WARNING"

### DIFF
--- a/Client/Function/Communication.d.lua
+++ b/Client/Function/Communication.d.lua
@@ -48,7 +48,7 @@ function SendAddonMessage(prefix, message, type) end
 --- if (i ~= nil) then SendChatMessage(s , "CHANNEL", nil, index) end
 --- ```
 ---@param message string At most 255 1-byte characters.
----@param type "BATTLEGROUND" | "GUILD" | "PARTY" | "RAID" | "SAY"
+---@param type "BATTLEGROUND" | "GUILD" | "PARTY" | "RAID" | "RAID_WARNING" | "SAY"
 ---@param language? string
 function SendChatMessage(message, type, language) end
 ---


### PR DESCRIPTION
You should be able to send raid_warning messages.

@SabineWren These are normally also not case sensitive.

https://github.com/user-attachments/assets/6a48ac61-b096-46da-a583-76ebe18c6e12

